### PR TITLE
fix: update syntax for File.exist?

### DIFF
--- a/ext/icu/extconf.rb
+++ b/ext/icu/extconf.rb
@@ -29,7 +29,7 @@ if using_system_libraries?
   unless dir_config('icu').any?
     base = if !`which brew`.empty?
              `brew --prefix`.strip
-           elsif File.exists?("/usr/local/Cellar/icu4c")
+           elsif File.exist?("/usr/local/Cellar/icu4c")
              '/usr/local/Cellar'
            end
 


### PR DESCRIPTION
This gem doesn't install in mri ruby 3.2 because it uses `File.exists?` in `ext/icu/extconf.rb`, which has been [deprecated](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/). 

This pull request contains the fix. 